### PR TITLE
Feat/create seeders

### DIFF
--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -25,11 +25,7 @@ class CustomerController extends Controller
      */
     public function create()
     {
-        $result = [
-            "response" => "Welcome",
-        ];
-
-        return response()->json($result);
+        return response()->json(['message' => 'Not Implemented.'], 501);
     }
 
     /**
@@ -40,7 +36,11 @@ class CustomerController extends Controller
      */
     public function store(Request $request)
     {
-        return response()->json(['message' => 'Not Implemented.'], 501);
+        $result = [
+            "response" => "Welcome",
+        ];
+
+        return response()->json($result);
     }
 
     /**

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
-
 final class OrderController extends Controller
 {
     /**

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -60,7 +60,7 @@ final class OrderController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param \Illuminate\Http\OrderRequest $request
+     * @param \App\Http\Requests\OrderRequest $request
      * @return \Illuminate\Http\JsonResponse
      */
     public function store(OrderRequest $request)
@@ -97,7 +97,7 @@ final class OrderController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param \Illuminate\Http\CompleteOrderRequest $request
+     * @param \App\Http\Requests\CompleteOrderRequest $request
      * @param int $id
      * @return \Illuminate\Http\JsonResponse
      */

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -56,11 +56,7 @@ final class OrderController extends Controller
      */
     public function create()
     {
-        $result = [
-            'response' => 'Create new order',
-        ];
-
-        return response()->json($result);
+        return response()->json(['message' => 'Not Implemented.'], 501);
     }
 
     /**
@@ -71,7 +67,11 @@ final class OrderController extends Controller
      */
     public function store(Request $request)
     {
-        return response()->json(['message' => 'Not Implemented.'], 501);
+        $result = [
+            'response' => 'Create new order',
+        ];
+
+        return response()->json($result);
     }
 
     /**
@@ -93,12 +93,7 @@ final class OrderController extends Controller
      */
     public function edit($id)
     {
-        $result = [
-            'id' => $id,
-            'response' => 'Complete order' . $id,
-        ];
-
-        return response()->json($result);
+        return response()->json(['message' => 'Not Implemented.'], 501);
     }
 
     /**
@@ -110,7 +105,12 @@ final class OrderController extends Controller
      */
     public function update(Request $request, $id)
     {
-        return response()->json(['message' => 'Not Implemented.'], 501);
+        $result = [
+            'id' => $id,
+            'response' => 'Complete order' . $id,
+        ];
+
+        return response()->json($result);
     }
 
     /**

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\CompleteOrderRequest;
+
 final class OrderController extends Controller
 {
     /**

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Http\Requests\CompleteOrderRequest;
+use App\Http\Requests\OrderRequest;
 
 final class OrderController extends Controller
 {

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -62,10 +62,10 @@ final class OrderController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param \Illuminate\Http\Request $request
+     * @param \Illuminate\Http\OrderRequest $request
      * @return \Illuminate\Http\JsonResponse
      */
-    public function store(Request $request)
+    public function store(OrderRequest $request)
     {
         $result = [
             'response' => 'Create new order',
@@ -99,11 +99,11 @@ final class OrderController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param \Illuminate\Http\Request $request
+     * @param \Illuminate\Http\CompleteOrderRequest $request
      * @param int $id
      * @return \Illuminate\Http\JsonResponse
      */
-    public function update(Request $request, $id)
+    public function update(CompleteOrderRequest $request, $id)
     {
         $result = [
             'id' => $id,

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -14,6 +14,7 @@ class VerifyCsrfToken extends Middleware
      * @var array<int, string>
      */
     protected $except = [
-        //
+        //　Because it is needed for testing.
+        'http://localhost/customers' // This is the url that I dont want Csrf for postman.
     ];
 }

--- a/app/Http/Requests/CompleteOrderRequest.php
+++ b/app/Http/Requests/CompleteOrderRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CompleteOrderRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/Requests/CustomerRequest.php
+++ b/app/Http/Requests/CustomerRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CustomerRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/Requests/OrderRequest.php
+++ b/app/Http/Requests/OrderRequest.php
@@ -26,7 +26,7 @@ class OrderRequest extends FormRequest
     public function rules()
     {
         return [
-            //
+            'order_items' => 'required',
         ];
     }
 }

--- a/app/Http/Requests/OrderRequest.php
+++ b/app/Http/Requests/OrderRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class OrderRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -11,7 +11,7 @@ class Category extends Model
 {
     use HasFactory;
 
-    protected $guarded = ['category_id', 'created_at', 'updated_at'];
+    protected $guarded = ['id', 'created_at'];
 
     public function items()
     {

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -11,7 +11,7 @@ class Customer extends Model
 {
     use HasFactory;
 
-    protected $guarded = ['customer_id', 'created_at', 'updated_at'];
+    protected $guarded = ['id', 'created_at'];
 
     public function orders()
     {

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -11,7 +11,7 @@ class Item extends Model
 {
     use HasFactory;
 
-    protected $guarded = ['item_id', 'created_at', 'updated_at'];
+    protected $guarded = ['id', 'created_at'];
 
     public function orderItems()
     {

--- a/app/Models/Option.php
+++ b/app/Models/Option.php
@@ -11,7 +11,7 @@ class Option extends Model
 {
     use HasFactory;
 
-    protected $guarded = ['option_id', 'created_at', 'updated_at'];
+    protected $guarded = ['id', 'created_at'];
 
     public function orderOptions()
     {

--- a/app/Models/OptionCategory.php
+++ b/app/Models/OptionCategory.php
@@ -11,7 +11,7 @@ class OptionCategory extends Model
 {
     use HasFactory;
 
-    protected $guarded = ['option_category_id', 'created_at', 'updated_at'];
+    protected $guarded = ['id', 'created_at'];
 
     public function options()
     {

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -11,7 +11,7 @@ class Order extends Model
 {
     use HasFactory;
 
-    protected $guarded = ['order_id', 'ordered_at', 'delivered_at'];
+    protected $guarded = ['id', 'created_at'];
 
     public function customer()
     {

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -11,7 +11,7 @@ class OrderItem extends Model
 {
     use HasFactory;
 
-    protected $guarded = ['order_item_id', 'created_at', 'updated_at'];
+    protected $guarded = ['id', 'created_at'];
 
     public function order()
     {

--- a/app/Models/OrderOption.php
+++ b/app/Models/OrderOption.php
@@ -11,7 +11,7 @@ class OrderOption extends Model
 {
     use HasFactory;
 
-    protected $guarded = ['order_option_id', 'created_at', 'updated_at'];
+    protected $guarded = ['id', 'created_at'];
 
     public function orderItem()
     {

--- a/app/Models/PriceHistory.php
+++ b/app/Models/PriceHistory.php
@@ -11,7 +11,7 @@ class PriceHistory extends Model
 {
     use HasFactory;
 
-    protected $guarded = ['price_history_id', 'configured_at', 'updated_at'];
+    protected $guarded = ['id', 'created_at'];
 
     public function items()
     {

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Category>
+ */
+class CategoryFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/factories/CustomerFactory.php
+++ b/database/factories/CustomerFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Customer>
+ */
+class CustomerFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/factories/CustomerFactory.php
+++ b/database/factories/CustomerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;

--- a/database/factories/ItemFactory.php
+++ b/database/factories/ItemFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;

--- a/database/factories/ItemFactory.php
+++ b/database/factories/ItemFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Item>
+ */
+class ItemFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/factories/OptionCategoryFactory.php
+++ b/database/factories/OptionCategoryFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;

--- a/database/factories/OptionCategoryFactory.php
+++ b/database/factories/OptionCategoryFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\OptionCategory>
+ */
+class OptionCategoryFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/factories/OptionFactory.php
+++ b/database/factories/OptionFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;

--- a/database/factories/OptionFactory.php
+++ b/database/factories/OptionFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Option>
+ */
+class OptionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/factories/OrderFactory.php
+++ b/database/factories/OrderFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;

--- a/database/factories/OrderFactory.php
+++ b/database/factories/OrderFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Order>
+ */
+class OrderFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/factories/OrderItemFactory.php
+++ b/database/factories/OrderItemFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\OrderItem>
+ */
+class OrderItemFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/factories/OrderItemFactory.php
+++ b/database/factories/OrderItemFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;

--- a/database/factories/OrderOptionFactory.php
+++ b/database/factories/OrderOptionFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;

--- a/database/factories/OrderOptionFactory.php
+++ b/database/factories/OrderOptionFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\OrderOption>
+ */
+class OrderOptionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/factories/PriceHistoryFactory.php
+++ b/database/factories/PriceHistoryFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;

--- a/database/factories/PriceHistoryFactory.php
+++ b/database/factories/PriceHistoryFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\PriceHistory>
+ */
+class PriceHistoryFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class CategorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //
+    }
+}

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Category;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -14,6 +15,12 @@ class CategorySeeder extends Seeder
      */
     public function run()
     {
-        //
+        Category::create([
+            'name' => '寿司',
+        ]);
+
+        Category::create([
+            'name' => 'ドリンク',
+        ]);
     }
 }

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -1,9 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Seeders;
 
 use App\Models\Category;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class CategorySeeder extends Seeder

--- a/database/seeders/CustomerSeeder.php
+++ b/database/seeders/CustomerSeeder.php
@@ -1,9 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Seeders;
 
 use App\Models\Customer;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class CustomerSeeder extends Seeder

--- a/database/seeders/CustomerSeeder.php
+++ b/database/seeders/CustomerSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Customer;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class CustomerSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        Customer::factory()->count(3)->create();
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Database\Seeders;
 
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+
+use App\Models\OptionCategory;
+use App\Models\PriceHistory;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -22,5 +25,16 @@ class DatabaseSeeder extends Seeder
         //     'name' => 'Test User',
         //     'email' => 'test@example.com',
         // ]);
+        $this->call([
+            CustomerSeeder::class,
+            OrderSeeder::class,
+            CategorySeeder::class,
+            OptionCategorySeeder::class,
+            PriceHistorySeeder::class,
+            ItemSeeder::class,
+            OptionSeeder::class,
+            OrderItemSeeder::class,
+            OrderOptionSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -6,8 +6,6 @@ namespace Database\Seeders;
 
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 
-use App\Models\OptionCategory;
-use App\Models\PriceHistory;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder

--- a/database/seeders/ItemSeeder.php
+++ b/database/seeders/ItemSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class ItemSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //
+    }
+}

--- a/database/seeders/ItemSeeder.php
+++ b/database/seeders/ItemSeeder.php
@@ -2,6 +2,9 @@
 
 namespace Database\Seeders;
 
+use App\Models\Category;
+use App\Models\Item;
+use App\Models\PriceHistory;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -14,6 +17,27 @@ class ItemSeeder extends Seeder
      */
     public function run()
     {
-        //
+        $sushi_id = Category::where('name', '寿司')->first()->value('id');
+        $sushi_price_id = PriceHistory::where('price', '200')->first()->value('id');
+        $drink_id = Category::where('name', 'ドリンク')->first()->value('id');
+        $drink_price_id = PriceHistory::where('price', '300')->first()->value('id');
+
+        Item::create([
+            'category_id' => $sushi_id,
+            'price_history_id' => $sushi_price_id,
+            'name' => 'まぐろ'
+        ]);
+
+        Item::create([
+            'category_id' => $sushi_id,
+            'price_history_id' => $sushi_price_id,
+            'name' => 'さけ'
+        ]);
+
+        Item::create([
+            'category_id' => $drink_id,
+            'price_history_id' => $drink_price_id,
+            'name' => 'りんごジュース'
+        ]);
     }
 }

--- a/database/seeders/ItemSeeder.php
+++ b/database/seeders/ItemSeeder.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Seeders;
 
 use App\Models\Category;
 use App\Models\Item;
 use App\Models\PriceHistory;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class ItemSeeder extends Seeder

--- a/database/seeders/ItemSeeder.php
+++ b/database/seeders/ItemSeeder.php
@@ -17,10 +17,10 @@ class ItemSeeder extends Seeder
      */
     public function run()
     {
-        $sushi_id = Category::where('name', '寿司')->first()->value('id');
-        $sushi_price_id = PriceHistory::where('price', '200')->first()->value('id');
-        $drink_id = Category::where('name', 'ドリンク')->first()->value('id');
-        $drink_price_id = PriceHistory::where('price', '300')->first()->value('id');
+        $sushi_id = Category::where('name', '寿司')->value('id');
+        $sushi_price_id = PriceHistory::where('price', '200')->value('id');
+        $drink_id = Category::where('name', 'ドリンク')->value('id');
+        $drink_price_id = PriceHistory::where('price', '300')->value('id');
 
         Item::create([
             'category_id' => $sushi_id,

--- a/database/seeders/OptionCategorySeeder.php
+++ b/database/seeders/OptionCategorySeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class OptionCategorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //
+    }
+}

--- a/database/seeders/OptionCategorySeeder.php
+++ b/database/seeders/OptionCategorySeeder.php
@@ -1,9 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Seeders;
 
 use App\Models\OptionCategory;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class OptionCategorySeeder extends Seeder

--- a/database/seeders/OptionCategorySeeder.php
+++ b/database/seeders/OptionCategorySeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\OptionCategory;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -14,6 +15,16 @@ class OptionCategorySeeder extends Seeder
      */
     public function run()
     {
-        //
+        OptionCategory::create([
+            'name' => 'サビ',
+        ]);
+
+        OptionCategory::create([
+            'name' => 'サイズ',
+        ]);
+
+        OptionCategory::create([
+            'name' => 'トッピング',
+        ]);
     }
 }

--- a/database/seeders/OptionSeeder.php
+++ b/database/seeders/OptionSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class OptionSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //
+    }
+}

--- a/database/seeders/OptionSeeder.php
+++ b/database/seeders/OptionSeeder.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Seeders;
 
 use App\Models\Option;
 use App\Models\OptionCategory;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class OptionSeeder extends Seeder

--- a/database/seeders/OptionSeeder.php
+++ b/database/seeders/OptionSeeder.php
@@ -2,6 +2,8 @@
 
 namespace Database\Seeders;
 
+use App\Models\Option;
+use App\Models\OptionCategory;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -14,6 +16,27 @@ class OptionSeeder extends Seeder
      */
     public function run()
     {
-        //
+        $wasabi_id = OptionCategory::where('name', 'サビ')->first()->value('id');
+        $size_id = OptionCategory::where('name', 'サイズ')->first()->value('id');
+
+        Option::create([
+            'option_category_id' => $wasabi_id,
+            'name' => '有り'
+        ]);
+
+        Option::create([
+            'option_category_id' => $wasabi_id,
+            'name' => '無し'
+        ]);
+
+        Option::create([
+            'option_category_id' => $size_id,
+            'name' => '並'
+        ]);
+
+        Option::create([
+            'option_category_id' => $size_id,
+            'name' => '特大'
+        ]);
     }
 }

--- a/database/seeders/OptionSeeder.php
+++ b/database/seeders/OptionSeeder.php
@@ -16,8 +16,8 @@ class OptionSeeder extends Seeder
      */
     public function run()
     {
-        $wasabi_id = OptionCategory::where('name', 'サビ')->first()->value('id');
-        $size_id = OptionCategory::where('name', 'サイズ')->first()->value('id');
+        $wasabi_id = OptionCategory::where('name', 'サビ')->value('id');
+        $size_id = OptionCategory::where('name', 'サイズ')->value('id');
 
         Option::create([
             'option_category_id' => $wasabi_id,

--- a/database/seeders/OrderItemSeeder.php
+++ b/database/seeders/OrderItemSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class OrderItemSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //
+    }
+}

--- a/database/seeders/OrderItemSeeder.php
+++ b/database/seeders/OrderItemSeeder.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class OrderItemSeeder extends Seeder

--- a/database/seeders/OrderOptionSeeder.php
+++ b/database/seeders/OrderOptionSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class OrderOptionSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //
+    }
+}

--- a/database/seeders/OrderOptionSeeder.php
+++ b/database/seeders/OrderOptionSeeder.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class OrderOptionSeeder extends Seeder

--- a/database/seeders/OrderSeeder.php
+++ b/database/seeders/OrderSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class OrderSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //
+    }
+}

--- a/database/seeders/OrderSeeder.php
+++ b/database/seeders/OrderSeeder.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class OrderSeeder extends Seeder

--- a/database/seeders/PriceHistorySeeder.php
+++ b/database/seeders/PriceHistorySeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class PriceHistorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //
+    }
+}

--- a/database/seeders/PriceHistorySeeder.php
+++ b/database/seeders/PriceHistorySeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\PriceHistory;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -14,6 +15,12 @@ class PriceHistorySeeder extends Seeder
      */
     public function run()
     {
-        //
+        PriceHistory::create([
+            'price' => 200,
+        ]);
+
+        PriceHistory::create([
+            'price' => 300,
+        ]);
     }
 }

--- a/database/seeders/PriceHistorySeeder.php
+++ b/database/seeders/PriceHistorySeeder.php
@@ -1,9 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Seeders;
 
 use App\Models\PriceHistory;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class PriceHistorySeeder extends Seeder

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
         volumes:
             - 'sail-mysql:/var/lib/mysql'
             - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
+            - './my.cnf:/etc/mysql/conf.d/my.cnf'
         networks:
             - sail
         healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
         volumes:
             - 'sail-mysql:/var/lib/mysql'
             - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
-            - './my.cnf:/etc/mysql/conf.d/my.cnf'
+            - './my.cnf:/etc/my.cnf'
         networks:
             - sail
         healthcheck:

--- a/my.cnf
+++ b/my.cnf
@@ -1,27 +1,3 @@
-#
-# The MySQL database server configuration file.
-#
-# You can copy this to one of:
-# - "/etc/mysql/my.cnf" to set global options,
-# - "~/.my.cnf" to set user-specific options.
-#
-# One can use all long options that the program supports.
-# Run program with --help to get a list of available options and with
-# --print-defaults to see which it would actually understand and use.
-#
-# For explanations see
-# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
-
-# This will be passed to all mysql clients
-# It has been reported that passwords should be enclosed with ticks/quotes
-# escpecially if they contain "#" chars...
-# Remember to edit /etc/mysql/debian.cnf when changing the socket location.
-
-# Here is entries for some specific programs
-# The following values assume you have at least 32M ram
-
-!includedir /etc/mysql/conf.d/
-
 [mysqld]
 character-set-server=utf8mb4
 collation-server=utf8mb4_general_ci

--- a/my.cnf
+++ b/my.cnf
@@ -1,0 +1,33 @@
+#
+# The MySQL database server configuration file.
+#
+# You can copy this to one of:
+# - "/etc/mysql/my.cnf" to set global options,
+# - "~/.my.cnf" to set user-specific options.
+#
+# One can use all long options that the program supports.
+# Run program with --help to get a list of available options and with
+# --print-defaults to see which it would actually understand and use.
+#
+# For explanations see
+# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+
+# This will be passed to all mysql clients
+# It has been reported that passwords should be enclosed with ticks/quotes
+# escpecially if they contain "#" chars...
+# Remember to edit /etc/mysql/debian.cnf when changing the socket location.
+
+# Here is entries for some specific programs
+# The following values assume you have at least 32M ram
+
+!includedir /etc/mysql/conf.d/
+
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_general_ci
+explicit-defaults-for-timestamp=1
+general-log=1
+general-log-file=/var/log/mysql/mysqld.log
+
+[client]
+default-character-set=utf8mb4

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,9 +25,9 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::post('/customers', [CustomerController::class, 'create']);
+Route::post('/customers', [CustomerController::class, 'store']);
 
-Route::post('/order-items', [OrderController::class, 'create']);
+Route::post('/order-items', [OrderController::class, 'store']);
 
 Route::get('/orders', [OrderController::class, 'index']);
 
@@ -43,4 +43,4 @@ Route::delete('/orders/{order_id}/delete-order', [OrderController::class, 'destr
 
 Route::get('/orders/uncompleted-order', [OrderController::class, 'indexUncompleted']);
 
-Route::patch('/orders/{order_id}/complete-order', [OrderController::class, 'edit']);
+Route::patch('/orders/{order_id}/complete-order', [OrderController::class, 'update']);


### PR DESCRIPTION
## 概要
`sail artisan db:seed`で初期データを用意出来るようにした。

### チケットURL
- [初期データの設定をする(Notion)](https://www.notion.so/yumemi/6f9b1f8e66cf414ba4edff40896d47a9)
- [MySQLを日本語対応にする(Notion)](https://www.notion.so/yumemi/MySQL-c68d1c717c15409d99b06e926845b464)

### 対応内容・対応背景・妥協点
- Seederファイルの用意
- MySQLを日本語対応にするための設定ファイルの用意

### やったこと
MySQLを日本語対応にするための設定ファイルをディレクトリ直下に用意し、Dockerと同期した。

### やってないこと

### 想定する動作
`sail artisan db:seed`で初期データを用意出来る。
dockerのMySQL内のデータが文字化けしていない。

### 特にレビューして欲しい点
MySQLを日本語対応でこの方法で適切かどうか。

### 補足事項
初期データの内容は今後変更するかもしれない。