### PR TITLE
Feat/implement request

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Models\Category;
+use App\Models\Item;
 use Illuminate\Http\Request;
 
 class CategoryController extends Controller
@@ -15,14 +17,9 @@ class CategoryController extends Controller
      */
     public function index()
     {
-        $result = [
-            'categories' => [
-                ['name' => 'sushi'],
-                ['name' => 'donburi'],
-                ['name' => 'ra-men'],
-            ],
-        ];
-        return response()->json($result);
+        $categories = Category::select('id', 'name')->get();
+
+        return response()->json($categories);
     }
 
     /**
@@ -52,17 +49,17 @@ class CategoryController extends Controller
      * @param int $id
      * @return \Illuminate\Http\JsonResponse
      */
-    public function show($id)
+    public function show($category_id)
     {
-        $result = [
-            'category_id' => $id,
-            'category_name' => '寿司',
-            'categories' => [
-                ['name' => 'maguro'],
-                ['name' => 'sake'],
-            ],
-        ];
-        return response()->json($result);
+        $items = Item::where('category_id', $category_id)
+            ->select('items.id', 'items.name', 'category_id', 'categories.name as category_name', 'price_history_id', 'price_histories.price')
+            ->join('categories', 'items.category_id', '=', 'categories.id')
+            ->join('price_histories', 'items.price_history_id', '=', 'price_histories.id')
+            ->orderBy('categories.id')
+            ->orderBy('price_histories.id')
+            ->get();
+
+        return response()->json($items);
     }
 
     /**

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
-use App\Models\Category;
-use App\Models\Item;
+use App\Repositories\CategoryRepository;
 use Illuminate\Http\Request;
 
 class CategoryController extends Controller
@@ -17,7 +16,7 @@ class CategoryController extends Controller
      */
     public function index()
     {
-        $categories = Category::select('id', 'name')->get();
+        $categories = CategoryRepository::getCategories();
 
         return response()->json($categories);
     }
@@ -51,13 +50,7 @@ class CategoryController extends Controller
      */
     public function show($category_id)
     {
-        $items = Item::where('category_id', $category_id)
-            ->select('items.id', 'items.name', 'category_id', 'categories.name as category_name', 'price_history_id', 'price_histories.price')
-            ->join('categories', 'items.category_id', '=', 'categories.id')
-            ->join('price_histories', 'items.price_history_id', '=', 'price_histories.id')
-            ->orderBy('categories.id')
-            ->orderBy('price_histories.id')
-            ->get();
+        $items = CategoryRepository::getCategoryItems($category_id);
 
         return response()->json($items);
     }

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -46,7 +46,7 @@ class CategoryController extends Controller
     /**
      * Display the specified resource.
      *
-     * @param int $id
+     * @param int $category_id
      * @return \Illuminate\Http\JsonResponse
      */
     public function show($category_id)

--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
-use App\Models\Customer;
+use App\Repositories\CustomerRepository;
 use Illuminate\Http\Request;
 
 class CustomerController extends Controller
@@ -37,10 +37,11 @@ class CustomerController extends Controller
      */
     public function store(Request $request)
     {
-        $customer = Customer::create();
+        $customer = CustomerRepository::saveCustomer();
 
         $result = [
             "response" => "Welcome",
+            "customer" => $customer,
         ];
 
         return response()->json($result);

--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Models\Customer;
 use Illuminate\Http\Request;
 
 class CustomerController extends Controller
@@ -36,6 +37,8 @@ class CustomerController extends Controller
      */
     public function store(Request $request)
     {
+        $customer = Customer::create();
+
         $result = [
             "response" => "Welcome",
         ];

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
-use App\Models\Item;
+use App\Repositories\ItemRepository;
 use Illuminate\Http\Request;
 
 class ItemController extends Controller
@@ -16,12 +16,7 @@ class ItemController extends Controller
      */
     public function index()
     {
-        $items = Item::select('items.name', 'category_id', 'categories.name as category_name', 'price_history_id', 'price_histories.price')
-            ->join('categories', 'items.category_id', '=', 'categories.id')
-            ->join('price_histories', 'items.price_history_id', '=', 'price_histories.id')
-            ->orderBy('categories.id')
-            ->orderBy('price_histories.id')
-            ->get();
+        $items = ItemRepository::getItems();
 
         return response()->json($items);
     }

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Models\Item;
 use Illuminate\Http\Request;
 
 class ItemController extends Controller
@@ -15,19 +16,14 @@ class ItemController extends Controller
      */
     public function index()
     {
-        $result = [
-            [
-                'name' => 'maguro',
-                'price' => 200,
-                'category_id' => 1
-            ],
-            [
-                'name' => 'sake',
-                'price' => 200,
-                'category_id' => 1
-            ],
-        ];
-        return response()->json($result);
+        $items = Item::select('items.name', 'category_id', 'categories.name as category_name', 'price_history_id', 'price_histories.price')
+            ->join('categories', 'items.category_id', '=', 'categories.id')
+            ->join('price_histories', 'items.price_history_id', '=', 'price_histories.id')
+            ->orderBy('categories.id')
+            ->orderBy('price_histories.id')
+            ->get();
+
+        return response()->json($items);
     }
 
     /**

--- a/app/Http/Controllers/OptionController.php
+++ b/app/Http/Controllers/OptionController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
-use App\Models\Option;
+use App\Repositories\OptionRepository;
 use Illuminate\Http\Request;
 
 class OptionController extends Controller
@@ -16,10 +16,7 @@ class OptionController extends Controller
      */
     public function index()
     {
-        $options = Option::select('options.id', 'options.name', 'option_category_id', 'option_categories.name as option_category_name')
-            ->join('option_categories', 'option_category_id', '=', 'option_categories.id')
-            ->orderBy('option_category_id')
-            ->get();
+        $options = OptionRepository::getOptions();
 
         return response()->json($options);
     }

--- a/app/Http/Controllers/OptionController.php
+++ b/app/Http/Controllers/OptionController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Models\Option;
 use Illuminate\Http\Request;
 
 class OptionController extends Controller
@@ -15,13 +16,12 @@ class OptionController extends Controller
      */
     public function index()
     {
-        $result = [
-            'options' => [
-                ['name' => 'マヨネーズ'],
-                ['name' => 'チリソース'],
-            ],
-        ];
-        return response()->json($result);
+        $options = Option::select('options.id', 'options.name', 'option_category_id', 'option_categories.name as option_category_name')
+            ->join('option_categories', 'option_category_id', '=', 'option_categories.id')
+            ->orderBy('option_category_id')
+            ->get();
+
+        return response()->json($options);
     }
 
     /**

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -6,10 +6,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\CompleteOrderRequest;
 use App\Http\Requests\OrderRequest;
-use App\Models\Order;
-use App\Models\OrderItem;
-use App\Models\OrderOption;
-use Carbon\Carbon;
+use App\Repositories\OrderRepository;
 
 final class OrderController extends Controller
 {
@@ -20,16 +17,11 @@ final class OrderController extends Controller
      */
     public function index()
     {
-        $order = Order::select('orders.id', 'table_number', 'total_price', 'order_items.price', 'order_items.amount', 'items.name as item_name', 'order_options.order_item_id', 'options.name as option_name', 'delivered_at')
-            ->rightJoin('order_items', 'orders.id', '=', 'order_items.order_id')
-            ->leftJoin('items', 'order_items.item_id', '=', 'items.id')
-            ->leftJoin('order_options', 'order_items.id', '=', 'order_options.order_item_id')
-            ->leftJoin('options', 'order_options.option_id', '=', 'options.id')
-            ->orderByDesc('orders.id')
-            ->orderByDesc('order_items.id')
-            ->get();
+        $orders = OrderRepository::getOrders();
+        // order_idが同じものをまとめて、レスポンスがネストされた状態にする
+        // eloquentコレクションを結合する
 
-        return response()->json($order);
+        return response()->json($orders);
     }
 
     /**
@@ -39,17 +31,11 @@ final class OrderController extends Controller
      */
     public function indexUncompleted()
     {
-        $order = Order::select('orders.id', 'table_number', 'total_price', 'order_items.price', 'order_items.amount', 'items.name as item_name', 'order_options.order_item_id', 'options.name as option_name', 'delivered_at')
-            ->rightJoin('order_items', 'orders.id', '=', 'order_items.order_id')
-            ->leftJoin('items', 'order_items.item_id', '=', 'items.id')
-            ->leftJoin('order_options', 'order_items.id', '=', 'order_options.order_item_id')
-            ->leftJoin('options', 'order_options.option_id', '=', 'options.id')
-            ->whereNull('delivered_at')
-            ->orderByDesc('orders.id')
-            ->orderByDesc('order_items.id')
-            ->get();
+        $orders = OrderRepository::getUncompletedOrders();
+        // order_idが同じものをまとめて、レスポンスがネストされた状態にする
+        // eloquentコレクションを結合する
 
-        return response()->json($order);
+        return response()->json($orders);
     }
 
     /**
@@ -71,33 +57,7 @@ final class OrderController extends Controller
     public function store(OrderRequest $request)
     {
         $validated = $request->validated();
-
-        $order = Order::create([
-            'customer_id' => $validated['customer_id'],
-            'total_price' => $validated['total_price'],
-            'table_number' => $validated['table_number'],
-        ]);
-
-        global $order_item;
-        foreach ($validated['order_items'] as $validated_item) {
-            $order_item = OrderItem::create([
-                'order_id' => $order->id,
-                'item_id' => $validated_item['item_id'],
-                'price' => $validated_item['price'],
-                'amount' => $validated_item['amount'],
-            ]);
-        }
-
-        // Needs improvement オーダーをする際に、"order_option_id"がどの"order_item_id"と関連しているかの判別が出来ていない
-        foreach ($validated['order_options'] as $validated_option) {
-            $order_option = OrderOption::create([
-                'order_item_id' => $order_item->id,
-                'option_id' => $validated_option['option_id'],
-            ]);
-        }
-
-        // order_idが同じものをまとめて、レスポンスがネストされた状態にする
-        // eloquentコレクションを結合する
+        OrderRepository::saveOrder($validated);
 
         $result = [
             'response' => 'Create new order',
@@ -138,21 +98,7 @@ final class OrderController extends Controller
      */
     public function update(CompleteOrderRequest $request, $order_id)
     {
-        $order = Order::find($order_id);
-        if (null === $order->delivered_at) {
-            $order->delivered_at = Carbon::now();
-            $order->save();
-
-            $result = [
-                'id' => $order_id,
-                'response' => 'Complete order: ' . $order_id,
-            ];
-        } else {
-            $result = [
-                'id' => $order_id,
-                'response' => 'Already completed order: ' . $order_id,
-            ];
-        }
+        $result = OrderRepository::completedOrder($order_id);
 
         return response()->json($result);
     }
@@ -165,7 +111,7 @@ final class OrderController extends Controller
      */
     public function destroy($order_id)
     {
-        Order::destroy($order_id);
+        OrderRepository::dropOrder($order_id);
 
         $result = [
             'id' => $order_id,

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\CompleteOrderRequest;
 use App\Http\Requests\OrderRequest;
+use App\Models\Item;
 use App\Models\Order;
 use App\Models\OrderItem;
 use App\Models\OrderOption;
@@ -19,24 +20,24 @@ final class OrderController extends Controller
      */
     public function index()
     {
-        $result = [
-            [
-                'table_number' => 1,
-                'order_items' => [
-                    'item_id' => 1,
-                    'name' => 'maguro',
-                    'price' => 200,
-                    'order_options' => [
-                        'option_id' => 1,
-                        'option_name' => 'mayonnaise',
-                    ],
-                    'amount' => 2,
-                    'delivered_at' => null,
-                ]
-            ]
-        ];
+        $order = Order::select('orders.id', 'table_number', 'total_price', 'order_items.price', 'order_items.amount', 'items.name as item_name', 'order_options.order_item_id', 'options.name as option_name', 'delivered_at')
+            ->rightJoin('order_items', 'orders.id', '=', 'order_items.order_id')
+            ->leftJoin('items', 'order_items.item_id', '=', 'items.id')
+            ->leftJoin('order_options', 'order_items.id', '=', 'order_options.order_item_id')
+            ->leftJoin('options', 'order_options.option_id', '=', 'options.id')
+            ->orderByDesc('orders.id')
+            ->get();
+        // サブクエリ
+        // $order_items = OrderItem::select('id', 'price', 'amount');
+        // $items = Item::all();
+        // $order = Order::select('orders.id', 'table_number', 'total_price', 'order_items.price', 'order_items.amount', 'delivered_at')
+        //     ->joinSub($order_items, 'order_items', function ($join) {
+        //         $join->on('orders.id', '=', 'order_items.id');
+        //     })
+        //     ->orderByDesc('orders.id')
+        //     ->get();
 
-        return response()->json($result);
+        return response()->json($order);
     }
 
     /**

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -158,6 +158,8 @@ final class OrderController extends Controller
      */
     public function destroy($order_id)
     {
+        Order::destroy($order_id);
+
         $result = [
             'id' => $order_id,
             'response' => 'Destroy order' . $order_id,

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -74,9 +74,9 @@ final class OrderController extends Controller
         $validated = $request->validated();
 
         $order = Order::create([
-            'customer_id' => $validated->customer_id,
-            'total_price' => $validated->total_price,
-            'table_number' => $validated->table_number,
+            'customer_id' => $validated['customer_id'],
+            'total_price' => $validated['total_price'],
+            'table_number' => $validated['table_number'],
         ]);
 
         foreach ($validated['order_items'] as $validated_item) {
@@ -102,7 +102,6 @@ final class OrderController extends Controller
 
         $result = [
             'response' => 'Create new order',
-            'request_data' => $request,
             'validated_data' => $validated,
         ];
 

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -81,6 +81,7 @@ final class OrderController extends Controller
         ]);
 
         foreach ($validated['order_items'] as $validated_item) {
+            global $order_item;
             $order_item = OrderItem::create([
                 'order_id' => $order->id,
                 'item_id' => $validated_item['item_id'],
@@ -94,6 +95,7 @@ final class OrderController extends Controller
             // ]);
         }
 
+        // オーダーをする際に、"order_option_id"がどの"order_item_id"と関連しているかの判別が出来ていない
         foreach ($validated['order_options'] as $validated_option) {
             $order_option = OrderOption::create([
                 'order_item_id' => $order_item->id,

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -86,20 +86,18 @@ final class OrderController extends Controller
                 'price' => $validated_item['price'],
                 'amount' => $validated_item['amount'],
             ]);
-
-            // $order_option = OrderOption::create([
-            //     'order_item_id' => $order_item->id,
-            //     'option_id' => $request['order_options']['option_id'],
-            // ]);
         }
 
-        // オーダーをする際に、"order_option_id"がどの"order_item_id"と関連しているかの判別が出来ていない
+        // Needs improvement オーダーをする際に、"order_option_id"がどの"order_item_id"と関連しているかの判別が出来ていない
         foreach ($validated['order_options'] as $validated_option) {
             $order_option = OrderOption::create([
                 'order_item_id' => $order_item->id,
                 'option_id' => $validated_option['option_id'],
             ]);
         }
+
+        // order_idが同じものをまとめて、レスポンスがネストされた状態にする
+        // eloquentコレクションを結合する
 
         $result = [
             'response' => 'Create new order',

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -6,6 +6,9 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\CompleteOrderRequest;
 use App\Http\Requests\OrderRequest;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\OrderOption;
 
 final class OrderController extends Controller
 {
@@ -68,6 +71,34 @@ final class OrderController extends Controller
      */
     public function store(OrderRequest $request)
     {
+        $request = $request->validated();
+        $order = Order::create([
+            'customer_id' => $request->customer_id,
+            'total_price' => $request->total_price,
+            'table_number' => $request->table_number,
+        ]);
+
+        foreach ($request['order_items'] as $request_item) {
+            $order_item = OrderItem::create([
+                'order_id' => $order->id,
+                'item_id' => $request_item['item_id'],
+                'price' => $request_item['price'],
+                'amount' => $request_item['amount'],
+            ]);
+
+            // $order_option = OrderOption::create([
+            //     'order_item_id' => $order_item->id,
+            //     'option_id' => $request['order_options']['option_id'],
+            // ]);
+        }
+
+        foreach ($request['order_options'] as $request_option) {
+            $order_option = OrderOption::create([
+                'order_item_id' => $order_item->id,
+                'option_id' => $request_option['option_id'],
+            ]);
+        }
+
         $result = [
             'response' => 'Create new order',
         ];

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -80,8 +80,8 @@ final class OrderController extends Controller
             'table_number' => $validated['table_number'],
         ]);
 
+        global $order_item;
         foreach ($validated['order_items'] as $validated_item) {
-            global $order_item;
             $order_item = OrderItem::create([
                 'order_id' => $order->id,
                 'item_id' => $validated_item['item_id'],
@@ -153,14 +153,14 @@ final class OrderController extends Controller
     /**
      * Remove the specified resource from storage.
      *
-     * @param int $id
+     * @param int $order_id
      * @return \Illuminate\Http\JsonResponse
      */
-    public function destroy($id)
+    public function destroy($order_id)
     {
         $result = [
-            'id' => $id,
-            'response' => 'Destroy order' . $id,
+            'id' => $order_id,
+            'response' => 'Destroy order' . $order_id,
         ];
 
         return response()->json($result);

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -71,19 +71,20 @@ final class OrderController extends Controller
      */
     public function store(OrderRequest $request)
     {
-        $request = $request->validated();
+        $validated = $request->validated();
+
         $order = Order::create([
-            'customer_id' => $request->customer_id,
-            'total_price' => $request->total_price,
-            'table_number' => $request->table_number,
+            'customer_id' => $validated->customer_id,
+            'total_price' => $validated->total_price,
+            'table_number' => $validated->table_number,
         ]);
 
-        foreach ($request['order_items'] as $request_item) {
+        foreach ($validated['order_items'] as $validated_item) {
             $order_item = OrderItem::create([
                 'order_id' => $order->id,
-                'item_id' => $request_item['item_id'],
-                'price' => $request_item['price'],
-                'amount' => $request_item['amount'],
+                'item_id' => $validated_item['item_id'],
+                'price' => $validated_item['price'],
+                'amount' => $validated_item['amount'],
             ]);
 
             // $order_option = OrderOption::create([
@@ -92,15 +93,17 @@ final class OrderController extends Controller
             // ]);
         }
 
-        foreach ($request['order_options'] as $request_option) {
+        foreach ($validated['order_options'] as $validated_option) {
             $order_option = OrderOption::create([
                 'order_item_id' => $order_item->id,
-                'option_id' => $request_option['option_id'],
+                'option_id' => $validated_option['option_id'],
             ]);
         }
 
         $result = [
             'response' => 'Create new order',
+            'request_data' => $request,
+            'validated_data' => $validated,
         ];
 
         return response()->json($result);

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -15,6 +15,6 @@ class VerifyCsrfToken extends Middleware
      */
     protected $except = [
         //　Because it is needed for testing.
-        'http://localhost/customers' // This is the url that I dont want Csrf for postman.
+        // 'http://localhost/customers' // This is the url that I dont want Csrf for postman.
     ];
 }

--- a/app/Http/Requests/OrderRequest.php
+++ b/app/Http/Requests/OrderRequest.php
@@ -30,12 +30,10 @@ class OrderRequest extends FormRequest
             'customer_id' => ['required', 'numeric', 'integer'],
             'table_number' => ['required', 'numeric', 'integer'],
             'order_items' => ['required', 'array:order_id,item_id,price,amount'],
-            'order_items.*.order_id' => ['required', 'integer'],
             'order_items.*.item_id' => ['required', 'integer'],
             'order_items.*.price' => ['required', 'integer'],
             'order_items.*.amount' => ['required', 'integer'],
             'order_options' => ['required', 'array:order_item_id,option_id'],
-            'order_options.*.order_item_id' => ['required', 'integer'],
             'order_options.*.option_id' => ['required', 'integer'],
             'total_price' => ['required', 'integer'],
         ];

--- a/app/Http/Requests/OrderRequest.php
+++ b/app/Http/Requests/OrderRequest.php
@@ -27,13 +27,12 @@ class OrderRequest extends FormRequest
     public function rules()
     {
         return [
-            'customer_id' => ['required', 'numeric', 'integer'],
-            'table_number' => ['required', 'numeric', 'integer'],
-            'order_items' => ['required', 'array:order_id,item_id,price,amount'],
+            'table_number' => ['required', 'integer'],
+            'order_items' => ['required', 'array:item_id,price,amount'],
             'order_items.*.item_id' => ['required', 'integer'],
             'order_items.*.price' => ['required', 'integer'],
             'order_items.*.amount' => ['required', 'integer'],
-            'order_options' => ['required', 'array:order_item_id,option_id'],
+            'order_options' => ['required', 'array:option_id'],
             'order_options.*.option_id' => ['required', 'integer'],
             'total_price' => ['required', 'integer'],
         ];

--- a/app/Http/Requests/OrderRequest.php
+++ b/app/Http/Requests/OrderRequest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;  // 追加
+use Illuminate\Http\Exceptions\HttpResponseException;  // 追加
 
 class OrderRequest extends FormRequest
 {
@@ -27,14 +29,27 @@ class OrderRequest extends FormRequest
     public function rules()
     {
         return [
+            'customer_id' => ['required', 'integer'],
             'table_number' => ['required', 'integer'],
-            'order_items' => ['required', 'array:item_id,price,amount'],
+            'order_items' => ['required', 'array'],
             'order_items.*.item_id' => ['required', 'integer'],
             'order_items.*.price' => ['required', 'integer'],
             'order_items.*.amount' => ['required', 'integer'],
-            'order_options' => ['required', 'array:option_id'],
+            'order_options' => ['required', 'array'],
             'order_options.*.option_id' => ['required', 'integer'],
             'total_price' => ['required', 'integer'],
         ];
+    }
+
+    protected function failedValidation(Validator $validator)
+    {
+        $response['data']    = [];
+        $response['status']  = 'NG';
+        $response['summary'] = 'Failed validation.';
+        $response['errors']  = $validator->errors()->toArray();
+
+        throw new HttpResponseException(
+            response()->json($response, 422)
+        );
     }
 }

--- a/app/Http/Requests/OrderRequest.php
+++ b/app/Http/Requests/OrderRequest.php
@@ -27,6 +27,7 @@ class OrderRequest extends FormRequest
     public function rules()
     {
         return [
+            'customer_id' => ['required', 'numeric', 'integer'],
             'table_number' => ['required', 'numeric', 'integer'],
             'order_items' => ['required', 'array:order_id,item_id,price,amount'],
             'order_items.*.order_id' => ['required', 'numeric', 'integer'],

--- a/app/Http/Requests/OrderRequest.php
+++ b/app/Http/Requests/OrderRequest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Contracts\Validation\Validator;  // 追加
-use Illuminate\Http\Exceptions\HttpResponseException;  // 追加
+use Illuminate\Http\Exceptions\HttpResponseException;
 
 class OrderRequest extends FormRequest
 {

--- a/app/Http/Requests/OrderRequest.php
+++ b/app/Http/Requests/OrderRequest.php
@@ -30,14 +30,14 @@ class OrderRequest extends FormRequest
             'customer_id' => ['required', 'numeric', 'integer'],
             'table_number' => ['required', 'numeric', 'integer'],
             'order_items' => ['required', 'array:order_id,item_id,price,amount'],
-            'order_items.*.order_id' => ['required', 'numeric', 'integer'],
-            'order_items.*.item_id' => ['required', 'numeric', 'integer'],
-            'order_items.*.price' => ['required', 'numeric', 'integer'],
-            'order_items.*.amount' => ['required', 'numeric', 'integer'],
+            'order_items.*.order_id' => ['required', 'integer'],
+            'order_items.*.item_id' => ['required', 'integer'],
+            'order_items.*.price' => ['required', 'integer'],
+            'order_items.*.amount' => ['required', 'integer'],
             'order_options' => ['required', 'array:order_item_id,option_id'],
-            'order_options.*.order_item_id' => ['required', 'numeric', 'integer'],
-            'order_options.*.option_id' => ['required', 'numeric', 'integer'],
-            'total_price' => ['required', 'numeric', 'integer'],
+            'order_options.*.order_item_id' => ['required', 'integer'],
+            'order_options.*.option_id' => ['required', 'integer'],
+            'total_price' => ['required', 'integer'],
         ];
     }
 }

--- a/app/Repositories/CategoryRepository.php
+++ b/app/Repositories/CategoryRepository.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+use App\Models\Category;
+use App\Models\Item;
+
+class CategoryRepository
+{
+    public static function getCategories()
+    {
+        $categories = Category::select('id', 'name')->get();
+
+        return $categories;
+    }
+
+    public static function getCategoryItems(int $category_id)
+    {
+        $items = Item::where('category_id', $category_id)
+            ->select('items.id', 'items.name', 'category_id', 'categories.name as category_name', 'price_history_id', 'price_histories.price')
+            ->join('categories', 'items.category_id', '=', 'categories.id')
+            ->join('price_histories', 'items.price_history_id', '=', 'price_histories.id')
+            ->orderBy('categories.id')
+            ->orderBy('price_histories.id')
+            ->get();
+
+        return $items;
+    }
+}

--- a/app/Repositories/CustomerRepository.php
+++ b/app/Repositories/CustomerRepository.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+use App\Models\Customer;
+
+class CustomerRepository
+{
+    public static function saveCustomer()
+    {
+        $customer = Customer::create();
+
+        return $customer;
+    }
+}

--- a/app/Repositories/ItemRepository.php
+++ b/app/Repositories/ItemRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+use App\Models\Item;
+
+class ItemRepository
+{
+    public static function getItems()
+    {
+        $items = Item::select('items.name', 'category_id', 'categories.name as category_name', 'price_history_id', 'price_histories.price')
+            ->join('categories', 'items.category_id', '=', 'categories.id')
+            ->join('price_histories', 'items.price_history_id', '=', 'price_histories.id')
+            ->orderBy('categories.id')
+            ->orderBy('price_histories.id')
+            ->get();
+
+        return $items;
+    }
+}

--- a/app/Repositories/OptionRepository.php
+++ b/app/Repositories/OptionRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+use App\Models\Option;
+
+class OptionRepository
+{
+    public static function getOptions()
+    {
+        $options = Option::select('options.id', 'options.name', 'option_category_id', 'option_categories.name as option_category_name')
+            ->join('option_categories', 'option_category_id', '=', 'option_categories.id')
+            ->orderBy('option_category_id')
+            ->get();
+
+        return $options;
+    }
+}

--- a/app/Repositories/OrderRepository.php
+++ b/app/Repositories/OrderRepository.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+use App\Http\Requests\OrderRequest;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\OrderOption;
+use Carbon\Carbon;
+
+final class OrderRepository
+{
+    public static function getOrders()
+    {
+        $orders = Order::select('orders.id', 'table_number', 'total_price', 'order_items.price', 'order_items.amount', 'items.name as item_name', 'order_options.order_item_id', 'options.name as option_name', 'delivered_at')
+            ->rightJoin('order_items', 'orders.id', '=', 'order_items.order_id')
+            ->leftJoin('items', 'order_items.item_id', '=', 'items.id')
+            ->leftJoin('order_options', 'order_items.id', '=', 'order_options.order_item_id')
+            ->leftJoin('options', 'order_options.option_id', '=', 'options.id')
+            ->orderByDesc('orders.id')
+            ->orderByDesc('order_items.id')
+            ->get();
+
+        return $orders;
+    }
+
+    public static function getUncompletedOrders()
+    {
+        $orders = Order::select('orders.id', 'table_number', 'total_price', 'order_items.price', 'order_items.amount', 'items.name as item_name', 'order_options.order_item_id', 'options.name as option_name', 'delivered_at')
+            ->rightJoin('order_items', 'orders.id', '=', 'order_items.order_id')
+            ->leftJoin('items', 'order_items.item_id', '=', 'items.id')
+            ->leftJoin('order_options', 'order_items.id', '=', 'order_options.order_item_id')
+            ->leftJoin('options', 'order_options.option_id', '=', 'options.id')
+            ->whereNull('delivered_at')
+            ->orderByDesc('orders.id')
+            ->orderByDesc('order_items.id')
+            ->get();
+
+        return $orders;
+    }
+
+    public static function saveOrder(OrderRequest $validated)
+    {
+        $order = Order::create([
+            'customer_id' => $validated['customer_id'],
+            'total_price' => $validated['total_price'],
+            'table_number' => $validated['table_number'],
+        ]);
+
+        global $order_item;
+        foreach ($validated['order_items'] as $validated_item) {
+            $order_item = OrderItem::create([
+                'order_id' => $order->id,
+                'item_id' => $validated_item['item_id'],
+                'price' => $validated_item['price'],
+                'amount' => $validated_item['amount'],
+            ]);
+        }
+
+        // Needs improvement オーダーをする際に、"order_option_id"がどの"order_item_id"と関連しているかの判別が出来ていない
+        foreach ($validated['order_options'] as $validated_option) {
+            $order_option = OrderOption::create([
+                'order_item_id' => $order_item->id,
+                'option_id' => $validated_option['option_id'],
+            ]);
+        }
+
+        return;
+    }
+
+    public static function completedOrder(int $order_id)
+    {
+        $order = Order::find($order_id);
+        if (null === $order->delivered_at) {
+            $order->delivered_at = Carbon::now();
+            $order->save();
+
+            $result = [
+                'id' => $order_id,
+                'response' => 'Complete order: ' . $order_id,
+            ];
+        } else {
+            $result = [
+                'id' => $order_id,
+                'response' => 'Already completed order: ' . $order_id,
+            ];
+        }
+
+        return $result;
+    }
+
+    public static function dropOrder(int $order_id)
+    {
+        Order::destroy($order_id);
+
+        return;
+    }
+}

--- a/database/migrations/2022_12_06_185713_create_orders_table.php
+++ b/database/migrations/2022_12_06_185713_create_orders_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
     {
         Schema::create('orders', function (Blueprint $table) {
             $table->id();
+            $table->unsignedInteger('table_number');
             $table->unsignedInteger('total_price');
             $table->dateTime('ordered_at')->nullable();
             $table->dateTime('delivered_at')->nullable();

--- a/database/migrations/2022_12_13_175829_create_order_items_table.php
+++ b/database/migrations/2022_12_13_175829_create_order_items_table.php
@@ -22,7 +22,7 @@ return new class extends Migration
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
 
-            $table->foreignId('order_id')->constrained();
+            $table->foreignId('order_id')->constrained()->cascadeOnDelete();
             $table->foreignId('item_id')->constrained();
         });
     }

--- a/database/migrations/2022_12_13_180123_create_order_options_table.php
+++ b/database/migrations/2022_12_13_180123_create_order_options_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->dateTime('created_at');
             $table->dateTime('updated_at');
 
-            $table->foreignId('order_item_id')->constrained();
+            $table->foreignId('order_item_id')->constrained()->cascadeOnDelete();
             $table->foreignId('option_id')->constrained();
         });
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -41,7 +41,7 @@ Route::get('/categories/{category_id}/items', [CategoryController::class, 'show'
 
 Route::get('/options', [OptionController::class, 'index']);
 
-Route::delete('/orders/{order_id}/delete-order', [OrderController::class, 'destroy']); // unimplemented
+Route::delete('/orders/{order_id}/delete-order', [OrderController::class, 'destroy']);
 
 Route::get('/orders/uncompleted-order', [OrderController::class, 'indexUncompleted']); // unimplemented
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,7 +29,7 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 Route::post('/customers', [CustomerController::class, 'store']);
 
-Route::post('/order-items', [OrderController::class, 'store']); // unimplemented
+Route::post('/order-items', [OrderController::class, 'store']);
 
 Route::get('/orders', [OrderController::class, 'index']); // unimplemented
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -33,7 +33,7 @@ Route::post('/order-items', [OrderController::class, 'store']); // unimplemented
 
 Route::get('/orders', [OrderController::class, 'index']); // unimplemented
 
-Route::get('/items', [ItemController::class, 'index']); // unimplemented
+Route::get('/items', [ItemController::class, 'index']);
 
 Route::get('/categories', [CategoryController::class, 'index']); // unimplemented
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -35,11 +35,11 @@ Route::get('/orders', [OrderController::class, 'index']); // unimplemented
 
 Route::get('/items', [ItemController::class, 'index']);
 
-Route::get('/categories', [CategoryController::class, 'index']); // unimplemented
+Route::get('/categories', [CategoryController::class, 'index']);
 
-Route::get('/categories/{category_id}/items', [CategoryController::class, 'show']); // unimplemented
+Route::get('/categories/{category_id}/items', [CategoryController::class, 'show']);
 
-Route::get('/options', [OptionController::class, 'index']); // unimplemented
+Route::get('/options', [OptionController::class, 'index']);
 
 Route::delete('/orders/{order_id}/delete-order', [OrderController::class, 'destroy']); // unimplemented
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,7 +29,7 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 Route::post('/customers', [CustomerController::class, 'store']);
 
-Route::post('/order-items', [OrderController::class, 'store']);
+Route::post('/order-items', [OrderController::class, 'store']); // Needs improvement
 
 Route::get('/orders', [OrderController::class, 'index']);
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -27,22 +27,22 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-Route::post('/customers', [CustomerController::class, 'store']);
+Route::post('/customers', [CustomerController::class, 'store']); // unimplemented
 
-Route::post('/order-items', [OrderController::class, 'store']);
+Route::post('/order-items', [OrderController::class, 'store']); // unimplemented
 
-Route::get('/orders', [OrderController::class, 'index']);
+Route::get('/orders', [OrderController::class, 'index']); // unimplemented
 
-Route::get('/items', [ItemController::class, 'index']);
+Route::get('/items', [ItemController::class, 'index']); // unimplemented
 
-Route::get('/categories', [CategoryController::class, 'index']);
+Route::get('/categories', [CategoryController::class, 'index']); // unimplemented
 
-Route::get('/categories/{category_id}/items', [CategoryController::class, 'show']);
+Route::get('/categories/{category_id}/items', [CategoryController::class, 'show']); // unimplemented
 
-Route::get('/options', [OptionController::class, 'index']);
+Route::get('/options', [OptionController::class, 'index']); // unimplemented
 
-Route::delete('/orders/{order_id}/delete-order', [OrderController::class, 'destroy']);
+Route::delete('/orders/{order_id}/delete-order', [OrderController::class, 'destroy']); // unimplemented
 
-Route::get('/orders/uncompleted-order', [OrderController::class, 'indexUncompleted']);
+Route::get('/orders/uncompleted-order', [OrderController::class, 'indexUncompleted']); // unimplemented
 
-Route::patch('/orders/{order_id}/complete-order', [OrderController::class, 'update']);
+Route::patch('/orders/{order_id}/complete-order', [OrderController::class, 'update']); // unimplemented

--- a/routes/api.php
+++ b/routes/api.php
@@ -27,7 +27,7 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-Route::post('/customers', [CustomerController::class, 'store']); // unimplemented
+Route::post('/customers', [CustomerController::class, 'store']);
 
 Route::post('/order-items', [OrderController::class, 'store']); // unimplemented
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -31,7 +31,7 @@ Route::post('/customers', [CustomerController::class, 'store']);
 
 Route::post('/order-items', [OrderController::class, 'store']);
 
-Route::get('/orders', [OrderController::class, 'index']); // unimplemented
+Route::get('/orders', [OrderController::class, 'index']);
 
 Route::get('/items', [ItemController::class, 'index']);
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\CategoryController;
+use App\Http\Controllers\CustomerController;
+use App\Http\Controllers\ItemController;
+
+use App\Http\Controllers\OptionController;
+use App\Http\Controllers\OrderController;
+
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -19,3 +26,23 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::post('/customers', [CustomerController::class, 'store']);
+
+Route::post('/order-items', [OrderController::class, 'store']);
+
+Route::get('/orders', [OrderController::class, 'index']);
+
+Route::get('/items', [ItemController::class, 'index']);
+
+Route::get('/categories', [CategoryController::class, 'index']);
+
+Route::get('/categories/{category_id}/items', [CategoryController::class, 'show']);
+
+Route::get('/options', [OptionController::class, 'index']);
+
+Route::delete('/orders/{order_id}/delete-order', [OrderController::class, 'destroy']);
+
+Route::get('/orders/uncompleted-order', [OrderController::class, 'indexUncompleted']);
+
+Route::patch('/orders/{order_id}/complete-order', [OrderController::class, 'update']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -43,6 +43,6 @@ Route::get('/options', [OptionController::class, 'index']);
 
 Route::delete('/orders/{order_id}/delete-order', [OrderController::class, 'destroy']);
 
-Route::get('/orders/uncompleted-order', [OrderController::class, 'indexUncompleted']); // unimplemented
+Route::get('/orders/uncompleted-orders', [OrderController::class, 'indexUncompleted']);
 
-Route::patch('/orders/{order_id}/complete-order', [OrderController::class, 'update']); // unimplemented
+Route::patch('/orders/{order_id}/complete-order', [OrderController::class, 'update']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,12 +2,6 @@
 
 declare(strict_types=1);
 
-use App\Http\Controllers\CategoryController;
-use App\Http\Controllers\CustomerController;
-use App\Http\Controllers\ItemController;
-
-use App\Http\Controllers\OptionController;
-use App\Http\Controllers\OrderController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -24,23 +18,3 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
-
-Route::post('/customers', [CustomerController::class, 'store']);
-
-Route::post('/order-items', [OrderController::class, 'store']);
-
-Route::get('/orders', [OrderController::class, 'index']);
-
-Route::get('/items', [ItemController::class, 'index']);
-
-Route::get('/categories', [CategoryController::class, 'index']);
-
-Route::get('/categories/{category_id}/items', [CategoryController::class, 'show']);
-
-Route::get('/options', [OptionController::class, 'index']);
-
-Route::delete('/orders/{order_id}/delete-order', [OrderController::class, 'destroy']);
-
-Route::get('/orders/uncompleted-order', [OrderController::class, 'indexUncompleted']);
-
-Route::patch('/orders/{order_id}/complete-order', [OrderController::class, 'update']);


### PR DESCRIPTION
## 概要
リクエストを送ることで、DBを操作出来るように実装する。#10

### チケットURL
- [requestでDBの操作をする（Notion）](https://www.notion.so/yumemi/request-DB-9856f21fa3a949f8ab9ea4483c8e98db)
- [設計](https://www.notion.so/yumemi/eb25339d25d942d592ca90ffdde2e38e#0555f31562914cff814d99311ee2085d)

### 対応内容・対応背景・妥協点
リクエストを送ることで、DBを操作し設計通りのレスポンスが返ってくるようにした。
メニュー追加などのお店側に必要だと考えられるAPIの実装はしていない。

### やったこと
ControllerにEloquentを使ったDBの操作を実装した。

### やってないこと
認証は今後client-id(header)を使い、実装する予定。#12

### 想定する動作
リクエストを送ることで、設計通りのレスポンスが返ってくる。

### 特にレビューして欲しい点
N+1問題などの問題がDBにアクセスする際に発生していないか。

### 補足事項
- オーダーを取得する、GET /ordersにリクエストを送った際にレスポンスがネストになっていない。
(バックでorder_idが同じものをeloquentコレクションを結合することでレスポンスがネストされた状態にするか、フロントで結合すると想定して対応しないか) #15
- "order-items"ルートのPOSTによるオーダーをする際に、"order_option_id"がどの"order_item_id"と関連しているかの判別が出来ていない。
その為、今後修正出来たらする予定。
