### PR TITLE
Feat/header authentication

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -65,5 +65,6 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'verified.client_id' => \App\Http\Middleware\EnsureClientIdIsValid::class,
     ];
 }

--- a/app/Http/Middleware/EnsureClientIdIsValid.php
+++ b/app/Http/Middleware/EnsureClientIdIsValid.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureClientIdIsValid
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $valid_store_client_id = config('sushi_order_system.valid_store_client_id');
+        $message = 'Forbidden: 閲覧権限が無いコンテンツ';
+        $description = 'client_id is invalid';
+
+        if (! ($request->header('client-id') === $valid_store_client_id)) {
+            return response()->json([
+                'error' => $message,
+                'error_description' => $description,
+                'error_code' => Response::HTTP_FORBIDDEN,
+            ], Response::HTTP_FORBIDDEN);
+        }
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/EnsureClientIdIsValid.php
+++ b/app/Http/Middleware/EnsureClientIdIsValid.php
@@ -15,7 +15,7 @@ class EnsureClientIdIsValid
      *
      * @param \Illuminate\Http\Request $request
      * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
-     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     * @return \Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
      */
     public function handle(Request $request, Closure $next)
     {

--- a/app/Repositories/OrderRepository.php
+++ b/app/Repositories/OrderRepository.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Repositories;
 
-use App\Http\Requests\OrderRequest;
 use App\Models\Order;
 use App\Models\OrderItem;
 use App\Models\OrderOption;

--- a/app/Repositories/OrderRepository.php
+++ b/app/Repositories/OrderRepository.php
@@ -41,7 +41,7 @@ final class OrderRepository
         return $orders;
     }
 
-    public static function saveOrder(OrderRequest $validated)
+    public static function saveOrder(array $validated)
     {
         $order = Order::create([
             'customer_id' => $validated['customer_id'],

--- a/config/sushi_order_system.php
+++ b/config/sushi_order_system.php
@@ -5,4 +5,5 @@ declare(strict_types=1);
 return [
     'sushi_recommended_system' => env('SUSHI_RECOMMENDED_SYSTEM', ''),
     'client_header' => env('SUSHI_RECOMMENDED_SYSTEM_CLIENT_HEADER', ''),
+    'valid_store_client_id' => env('VALID_STORE_CLIENT_ID', ''),
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -41,10 +41,10 @@ Route::get('/categories/{category_id}/items', [CategoryController::class, 'show'
 
 Route::get('/options', [OptionController::class, 'index']);
 
-Route::delete('/orders/{order_id}/delete-order', [OrderController::class, 'destroy']);
+Route::delete('/orders/{order_id}/delete-order', [OrderController::class, 'destroy'])->middleware(['verified.client_id']);
 
-Route::get('/orders/uncompleted-orders', [OrderController::class, 'indexUncompleted']);
+Route::get('/orders/uncompleted-orders', [OrderController::class, 'indexUncompleted'])->middleware(['verified.client_id']);
 
-Route::patch('/orders/{order_id}/complete-order', [OrderController::class, 'update']);
+Route::patch('/orders/{order_id}/complete-order', [OrderController::class, 'update'])->middleware(['verified.client_id']);
 
 Route::get('/recommended', RecommendedController::class);


### PR DESCRIPTION
## 概要
ヘッダーによる認証機能を実装する。#12

### チケットURL
- [認証による店員か客の判別を出来るようにする(Notion)](https://www.notion.so/yumemi/7c6f738bab0f4f72a43585076119b020?pvs=4)
- [API仕様](https://www.notion.so/yumemi/eb25339d25d942d592ca90ffdde2e38e?pvs=4#d0b5f04b704041a0834f1f25cc2dce19)

### 対応内容・対応背景・妥協点
店舗側アプリケーションからのリクエストか顧客側アプリケーションからのリクエストかを判別出来るようにする。
リクエストのヘッダーにclient-idを追加することで判別可能にする。

### やったこと
店舗側アプリケーションしかアクセス出来ないAPIには、client-idをを調べるミドルウェアを追加する。

### やってないこと
ログイン機能などは実装していない。

### 想定する動作
client-idの値が正しい場合は、リクエストを受け付ける。
client-idの値が正しくない場合は、アクセスを拒否する。

### 特にレビューして欲しい点

### 補足事項
FormRequestのauthorizeメソッドでも認証機能を実装出来たが、複数箇所で必要だったので今回はミドルウェアで実装した。
